### PR TITLE
CI use only one OS and latest NodeJS lts for Github actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,8 +13,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.x, 14.x, 15.x]
+        os: [ubuntu-latest]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Simplify CI with only one OS, and latest LTS NodeJS

